### PR TITLE
Pointed observation method to collection in Observation method vocab

### DIFF
--- a/ckanext/scheming/seismic.json
+++ b/ckanext/scheming/seismic.json
@@ -61,7 +61,7 @@
       "field_name": "observation_method",
       "label": "Observation method",
       "preset": "select_ajax",
-      "resource_url": "https://vocabs.gsq.digital/endpoint?query=PREFIX%20skos%3A%3Chttp%3A%2F%2Fwww.w3.org%2F2004%2F02%2Fskos%2Fcore%23%3ESELECT%3Fconcept%3FprefLabel%20WHERE%7B%3Fconcept%20a%20skos%3AConcept%3Bskos%3AprefLabel%3FprefLabel%3Bskos%3AinScheme%20%3Chttp%3A%2F%2Flinked.data.gov.au%2Fdef%2Fseismic-sampling-method%3E.%7Dorder%20by%20%3FprefLabel&Accept=application/sparql-results+json",
+      "resource_url": "https://vocabs.gsq.digital/endpoint?query=PREFIX%20skos%3A%3Chttp%3A%2F%2Fwww.w3.org%2F2004%2F02%2Fskos%2Fcore%23%3E%20SELECT%20%3Fconcept%20%3FprefLabel%20WHERE%7B%3Chttp%3A%2F%2Flinked.data.gov.au%2Fdef%2Fgeological-observation-method%2Fseismic-methods%3E%20skos%3Amember%20%3Fconcept.%20%3Fconcept%20skos%3AprefLabel%20%3FprefLabel.%7Dorder%20by%20%3FprefLabel&Accept=application/sparql-results+json",
       "choices": [],
       "display_property": "sosa:Actuator"
     },


### PR DESCRIPTION
Changed SPARQL query for the CKAN form drop-down for Observation Method to select from the collection http://linked.data.gov.au/def/geological-observation-method/seismic-methods